### PR TITLE
SED-621-add-hooks-before-keyword-call-and-after-keyword-call-to-abstract-keyword-class

### DIFF
--- a/step-api-net/KeywordsForTesting/Keywords.cs
+++ b/step-api-net/KeywordsForTesting/Keywords.cs
@@ -15,7 +15,7 @@ namespace KeywordsForTesting
             output.Add("BeforeKeyword", KeywordName);
         }
 
-        public override void AfterKeyword(String KeywordName, Keyword Annotation, bool HadError)
+        public override void AfterKeyword(String KeywordName, Keyword Annotation)
         {
             output.Add("AfterKeyword", KeywordName);
         }

--- a/step-api-net/StepApiKeyword/Executor.cs
+++ b/step-api-net/StepApiKeyword/Executor.cs
@@ -145,7 +145,6 @@ namespace Step.Handlers.NetHandler
                     script.properties = keywordProperties;
                 }
 
-                bool HadError = false;
                 String keywordName = keyword.name ?? method.Name;
                 try
                 {
@@ -154,12 +153,11 @@ namespace Step.Handlers.NetHandler
                 }
                 catch (Exception e)
                 {
-                    HadError = true;
                     CallOnError(c, e, methodName, alwaysThrowException);
                 }
                 finally
                 {
-                    script?.AfterKeyword(keywordName, keyword, HadError);
+                    script?.AfterKeyword(keywordName, keyword);
                 }
             }
             catch (Exception e)

--- a/step-api-net/StepApiKeyword/Keyword.cs
+++ b/step-api-net/StepApiKeyword/Keyword.cs
@@ -31,8 +31,7 @@ namespace Step.Handlers.NetHandler
         public TokenSession tokenSession;
 
         /// <summary>
-        /// Hook called when an exception is thrown by a keyword or by the BeforeKeyword 
-        /// and AfterKeyword hooks
+        /// Hook called when an exception is thrown by a keyword or by the BeforeKeyword hooks
         /// </summary>
         /// <param name="e">the exception thrown</param>
         /// <returns>return true if the exception passed as argument has to be rethrown</returns>
@@ -43,8 +42,8 @@ namespace Step.Handlers.NetHandler
 
         /// <summary>
         /// Hook called before each keyword call.
-        /// If an error is thrown by this function, nor the keyword nor
-        /// the afterKeyword hook will be called(but onError will be)
+        /// If an exception is thrown by this method, the keyword won't be executed 
+        /// (but AfterKeyword and OnError will)
         /// </summary>
         /// <param name="KeywordName">the name of the keyword.  Will be the function name if annotation.name is empty </param>
         /// <param name="Annotation">the annotation of the called keyword</param>
@@ -52,12 +51,11 @@ namespace Step.Handlers.NetHandler
 
         /// <summary>
         /// Hook called after each keyword call.
-        /// If an error is thrown by the keyword or the beforeKeyword hook,
-        /// the afterKeyword hook will be called with hadError to true
+        /// This method is always called. If an exception is thrown by the keyword or the BeforeKeyword hook,
+        /// this method is called after the OnError hook.
         /// </summary>
         /// <param name="KeywordName">the name of the keyword.  Will be the function name if annotation.name is empty </param>
         /// <param name="Annotation">the annotation of the called keyword</param>
-        /// <param name="HadError">if an error occurred</param>
-        public virtual void AfterKeyword(String KeywordName, Keyword Annotation, bool HadError) { }
+        public virtual void AfterKeyword(String KeywordName, Keyword Annotation) { }
     }
 }

--- a/step-api-net/StepApiKeywordTests/KeywordRunnerTests.cs
+++ b/step-api-net/StepApiKeywordTests/KeywordRunnerTests.cs
@@ -168,7 +168,7 @@ namespace Step.Handlers.NetHandler.Tests
 
             var output = runner.Run("MyKeywordWithPropertyAnnotation", @"{}", properties);
             Assert.Equal("val1", output.payload["prop1"].ToString());
-            Assert.Equal(4,output.payload.Count);
+            Assert.Equal(3,output.payload.Count);
             Assert.Null(output.error);
         }
 
@@ -203,7 +203,7 @@ namespace Step.Handlers.NetHandler.Tests
 
             var output = runner.Run("MyKeywordWithPlaceHoldersInProperties", @"{}", properties);
             Assert.Equal("My Property with Place holder", output.payload["prop.placeHolderValue"].ToString());
-            Assert.Equal(4, output.payload.Count);
+            Assert.Equal(3, output.payload.Count);
             Assert.Null(output.error);
         }
 
@@ -223,7 +223,7 @@ namespace Step.Handlers.NetHandler.Tests
 
             var output = runner.Run("MyKeywordWithPlaceHoldersInProperties", "{\"myPlaceHolder\": \"placeHolderValue\"}", properties);
             Assert.Equal("My Property with Place holder", output.payload["prop.placeHolderValue"].ToString());
-            Assert.Equal(4, output.payload.Count);
+            Assert.Equal(3, output.payload.Count);
             Assert.Null(output.error);
         }
 
@@ -243,7 +243,7 @@ namespace Step.Handlers.NetHandler.Tests
             var output = runner.Run("MyKeywordWithPlaceHoldersInProperties", "{\"myPlaceHolder\": \"placeHolderValue\"}", properties);
             Assert.Equal("My Property with Place holder", output.payload["prop.placeHolderValue"].ToString());
             Assert.Equal("My optional Property", output.payload["myOptionalProperty"].ToString());
-            Assert.Equal(5, output.payload.Count);
+            Assert.Equal(4, output.payload.Count);
             Assert.Null(output.error);
         }
 

--- a/step-api-net/StepApiKeywordTests/KeywordRunnerTests.cs
+++ b/step-api-net/StepApiKeywordTests/KeywordRunnerTests.cs
@@ -20,10 +20,9 @@ namespace Step.Handlers.NetHandler.Tests
             output.Add("BeforeKeyword", KeywordName);
         }
 
-        public override void AfterKeyword(String KeywordName, Keyword Annotation, bool HadError)
+        public override void AfterKeyword(String KeywordName, Keyword Annotation)
         {
             output.Add("AfterKeyword", KeywordName);
-            output.Add("HadError", HadError.ToString());
         }
 
         [Keyword(name = "My Keyword")]

--- a/step-api/step-api-keyword/src/main/java/step/handlers/javahandler/AbstractKeyword.java
+++ b/step-api/step-api-keyword/src/main/java/step/handlers/javahandler/AbstractKeyword.java
@@ -83,10 +83,11 @@ public class AbstractKeyword {
 	}
 
 	/**
-	 * Hook called when an exception is thrown by a keyword or by the BeforeKeyword
-	 * and AfterKeyword hooks
+	 * Hook called when an exception is thrown by a keyword or by the beforeKeyword hook
+	 *
 	 * @param e the exception thrown
 	 * @return true if the exception passed as argument has to be rethrown.
+	 * Set to false if the error has already been handled by this hook and shouldn't be handled.
 	 */
 	public boolean onError(Exception e) {
 		return true;
@@ -94,8 +95,7 @@ public class AbstractKeyword {
 
 	/**
 	 * Hook called before each keyword call.
-	 * If an error is thrown by this function, nor the keyword nor
-	 * the afterKeyword hook will be called (but onError will be)
+	 * If an exception is thrown by this method, the keyword won't be executed (but afterKeyword and onError will)
 	 *
 	 * @param keywordName the name of the keyword. Will be the function name if annotation.name() is empty
 	 * @param annotation the annotation of the called keyword
@@ -104,12 +104,11 @@ public class AbstractKeyword {
 
 	/**
 	 * Hook called after each keyword call.
-	 * If an error is thrown by the keyword or the beforeKeyword hook,
-	 * the afterKeyword hook will be called with hadError to true
+	 * This method is always called. If an exception is thrown by the keyword or the beforeKeyword hook,
+	 * this method is called after the onError hook.
 	 *
-	 * @param keywordName the name of the keyword. Will be the function name if annotation.name() is empty
+	 * @param keywordName the name of the keyword. Will be the method name if annotation.name() is empty
 	 * @param annotation the annotation of the called keyword
-	 * @param hadError if an error occurred
 	 */
-	public void afterKeyword(String keywordName, Keyword annotation, boolean hadError) {}
+	public void afterKeyword(String keywordName, Keyword annotation) {}
 }

--- a/step-api/step-api-keyword/src/main/java/step/handlers/javahandler/KeywordExecutor.java
+++ b/step-api/step-api-keyword/src/main/java/step/handlers/javahandler/KeywordExecutor.java
@@ -185,15 +185,12 @@ public class KeywordExecutor {
 			script.setProperties(properties);
 			script.setOutputBuilder(outputBuilder);
 
-			boolean hadError = false;
-
 			Keyword annotation = m.getAnnotation(Keyword.class);
 			String keywordName = input.getFunction();
 			try {
 				script.beforeKeyword(keywordName,annotation);
 				m.invoke(instance);
 			} catch (Exception e) {
-				hadError = true;
 				boolean throwException = script.onError(e);
 				if (throwException) {
 					Throwable cause = e.getCause();
@@ -210,7 +207,7 @@ public class KeywordExecutor {
 					}
 				}
 			} finally {
-				script.afterKeyword(keywordName,annotation,hadError);
+				script.afterKeyword(keywordName, annotation);
 			}
 		} else {
 			outputBuilder.add("Info", "The class '" + clazz.getName() + "' doesn't extend '" + AbstractKeyword.class.getName()

--- a/step-api/step-api-keyword/src/test/java/step/handlers/javahandler/MyKeywordLibrary.java
+++ b/step-api/step-api-keyword/src/test/java/step/handlers/javahandler/MyKeywordLibrary.java
@@ -23,14 +23,41 @@ import java.io.IOException;
 
 public class MyKeywordLibrary extends AbstractKeyword {
 
+	public static final String ON_ERROR_MARKER = "onError";
+	public static final String THROW_EXCEPTION_IN_AFTER = "throwExceptionInAfter";
+	public static final String THROW_EXCEPTION_IN_BEFORE = "throwExceptionInBefore";
+	public static final String RETHROW_EXCEPTION_IN_ON_ERROR = "rethrowException";
+
 	@Override
 	public void beforeKeyword(String keywordName,Keyword keyword) {
 		output.add("beforeKeyword",keywordName);
+		if(getBooleanProperty(THROW_EXCEPTION_IN_BEFORE)) {
+			throw new RuntimeException(THROW_EXCEPTION_IN_BEFORE);
+		}
+
 	}
 
 	@Override
-	public void afterKeyword(String keywordName,Keyword keyword, boolean hadError) {
+	public void afterKeyword(String keywordName,Keyword keyword) {
 		output.add("afterKeyword",keywordName);
+		if(getBooleanProperty(THROW_EXCEPTION_IN_AFTER)) {
+			throw new RuntimeException(THROW_EXCEPTION_IN_AFTER);
+		}
+	}
+
+	@Override
+	public boolean onError(Exception e) {
+		Throwable cause = e.getCause();
+		output.add(ON_ERROR_MARKER, cause != null ? cause.getMessage() : e.getMessage());
+		return getBooleanProperty(RETHROW_EXCEPTION_IN_ON_ERROR, true);
+	}
+
+	private boolean getBooleanProperty(String key) {
+		return Boolean.parseBoolean(properties.getOrDefault(key, Boolean.FALSE.toString()));
+	}
+
+	private boolean getBooleanProperty(String key, boolean defaultValue) {
+		return Boolean.parseBoolean(properties.getOrDefault(key, Boolean.toString(defaultValue)));
 	}
 
 	@Keyword


### PR DESCRIPTION
Performed following changes in Java API:
- Removed hadError flag from afterKeyword
- Fixed comments
- Added JUnit tests