### PR TITLE
SED-3439 Update dependencies for Step 26

### DIFF
--- a/step-api/pom.xml
+++ b/step-api/pom.xml
@@ -43,7 +43,7 @@
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 
-		<dependencies.version>2024.8.27</dependencies.version>
+		<dependencies.version>2024.9.26</dependencies.version>
 
 		<!-- maven build dependencies -->
 		<dep.mvn.jacoco.version>0.8.12</dep.mvn.jacoco.version>


### PR DESCRIPTION
This will become the new release, could be either 1.2.8 or 1.3.0 - I don't have a strong opinion.